### PR TITLE
Add "install" to pip command

### DIFF
--- a/source/contributing.rst
+++ b/source/contributing.rst
@@ -80,7 +80,7 @@ This downloads the repository into the folder you chose it will appear as a fold
 .. code-block::
 
     cd .\bteguide
-    pip -r requirements.txt
+    pip install -r requirements.txt
 
 This will install all packages you need to work on the wiki.
 Great, congratulations yoou are now set up and can start working on the wiki documents. 


### PR DESCRIPTION
Using pip without `install` causes an error to be thrown.
```
pi@raspberrypi:~/Desktop/bteguide $ pip -r requirements.txt

Usage:   
  /usr/bin/python3 -m pip <command> [options]

no such option: -r
```